### PR TITLE
Fix change password action

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@ unless you know exactly what you're doing! -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
 
-    <title>React App</title>
+    <title>Donuts-R-Us</title>
   </head>
   <body>
     <noscript>

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -43,7 +43,7 @@ export const changePassword = (passwords, user) => {
     url: apiUrl + '/change-password',
     method: 'PATCH',
     headers: {
-      'Authorization': `Token token=${user.token}`
+      'Authorization': `Bearer ${user.token}`
     },
     data: {
       passwords: {

--- a/src/components/Product/HomeIndexProducts.js
+++ b/src/components/Product/HomeIndexProducts.js
@@ -28,7 +28,6 @@ class HomeIndexProducts extends Component {
     } else {
       productsJSX =
           this.state.products.map((product, index) => {
-            console.log(product)
             return index < 5 &&
               <div key={product._id} className='d-flex row'>
                 <ProductCard className="col-4"


### PR DESCRIPTION
The change password token authorization was inconsistent with the API
call so it was changed. This takes care of a 401 unauthorized error that
was occurring